### PR TITLE
Minor grammatical changes

### DIFF
--- a/docs/build-graph.md
+++ b/docs/build-graph.md
@@ -1,13 +1,13 @@
 # Build Graph & Targets
 [⛓ README](/README.md)
 
-At its most basic, the Katamari build model consists of "tasks", "targets" and "products".
+At its most basic, the Katamari build model consists of "tasks," "targets" and "products".
 A **product** is just a fancy term for one or more files.
 Products are produced by **tasks**, which should be pure functions from products and other configuration to products.
 Products are anonymous by default, but may be given names.
 Named products are called **targets**.
 
-Lets take an example.
+Lets take an example:
 I want to automate the build for a Clojure application.
 My application has some resource and source files locally.
 I've got some Maven dependencies which need to be included.
@@ -17,7 +17,7 @@ Maybe I'm downloading data files from s3 or using some in-house tool to generate
 
 Traditionally in [leiningen](https://github.com/technomancy/leiningen), one would use [`:prep-tasks`](https://github.com/technomancy/leiningen/blob/master/sample.project.clj#L258-L262) to provide a sequence of tasks such as `javac` which will be executed before a goal such as `repl` or `test`.
 While this works, it's less than ideal in that all the tasks have to implement their own caching and change detection.
-Most don't at all, which makes the "simple" thing while correct often quite inefficient.
+Most don't at all, which makes the "simple" thing, while correct, often quite inefficient.
 
 By introducing a concrete concept of products and their dependency graph, the various Google Blaze derivatives all nicely sidestep this issue.
 Products are cached and need not be re-computed until they become invalidated by some change in the state of the system.
@@ -88,20 +88,20 @@ java_binary(
 ```
 
 Consider the `java_library` product.
-It's results are defined by `javac` over some set of source files, some options such as the target JVM version and some dependencies.
+Its results are defined by `javac` over some set of source files, some options such as the target JVM version and some dependencies.
 If we've never built for that combination before, we have to do so.
-If we're building again and already have that build parameter combination lying around, then our build tool can just hit in a cache, assuming the build is repeatable and the cache is good.
-However if one of the build inputs changed - say a source file was edited or a build parameter like the target JVM version was changed, then we have to do a new build.
+If we're building again and already have that build parameter combination lying around, then our build tool can just get a hit in a cache, assuming the build is repeatable and the cache is good.
+However if one of the build inputs changed - say a source file was edited or a build parameter like the target JVM version was changed - then we have to do a new build.
 
 There's plenty of room for refinement here.
-Good 'ol GNU Make uses file change timestamps as the metric of whether a build product is "up to date".
+Good 'ol GNU Make uses file change timestamps as the metric of whether a build product is "up to date."
 This has some significant limitations, especially when using a version control system like git which can cause files to time travel.
 The goal of Katamari and incremental build systems generally is to trade build artifact cache size on disk for rebuild rapidity wherever possible.
 Using file timestamps is a poor heuristic in this regard, because it means that one throws away the build cache when simply changing branches.
 
 Content-hashing (sha512sum or equivalent ([hasch](https://github.com/replikativ/hasch))) is the minimum acceptable content identifier, in that the content identifiers are reasonably unique and repeatable across branch changes.
 A design goal is to be pluggable with respect to content hashing algorithms.
-In a C file for instance, whitespace changes and comment changes don't* affect the interpretation of the source files by the compiler - consequently one could imagine writing a domain specific content hash operation which considers only the hash of non-lexical-whitespace in the file.
+In a C file for instance, whitespace changes and comment changes don't affect the interpretation of the source files by the compiler; consequently one could imagine writing a domain specific content hash operation which considers only the hash of non-lexical-whitespace in the file.
 Likewise for Lisp code, comments and whitespace are discarded.
 One could imagine content hashing the s-expression structure of the file to produce an identifier - or having a two step content hashing operation where straight file hashes are used to cache more precise content hashes.
 

--- a/docs/build-graph.md
+++ b/docs/build-graph.md
@@ -1,7 +1,7 @@
 # Build Graph & Targets
 [⛓ README](/README.md)
 
-At its most basic, the Katamari build model consists of "tasks," "targets" and "products".
+At its most basic, the Katamari build model consists of "tasks," "targets" and "products."
 A **product** is just a fancy term for one or more files.
 Products are produced by **tasks**, which should be pure functions from products and other configuration to products.
 Products are anonymous by default, but may be given names.


### PR DESCRIPTION
- proper, American-style quotation handling.
- one incorrect `it's` to `its`
- minor massage of `;` or `-` and some `,` handling.

Looks good otherwise, and makes sense. I like the ideas presented, and the named graphs are interesting. Could be neat to output to N3/N4 or Turtl for further analysis, but that's neither here nor there.