### PR TITLE
Fix a bug where kat would make an erroneous workdir

### DIFF
--- a/kat
+++ b/kat
@@ -223,9 +223,6 @@ function _ping_server() {
 
 # Start the server and wait for it to come back
 function _start_server() {
-    # Ensure the work dir
-    mkdir -p "${KAT_REPO_ROOT}/${KAT_SERVER_WORK_DIR}"
-
     # FIXME (arrdem 2018-09-29):
     #   Should be possible to time how long it takes the server to become available.
 


### PR DESCRIPTION
"${KAT_SERVER_WORK_DIR}" already includes "${KAT_REPO_ROOT}", so making the directory "${KAT_REPO_ROOT}/${KAT_SERVER_WORK_DIR}" was never correct because it created a directory (with parents!) from a repeated absolute path prefix.

As "${KAT_SERVER_WORK_DIR}" is already directly assured earlier in the script, just drop this instance of the behavior altogether.

This fixes a bug where I'd see Katamari make insane paths like 
```
+ mkdir -p /Users/reid.mckenzie/Documents/dat/git/arrdem/katamari//Users/reid.mckenzie/Documents/dat/git/arrdem/katamari/.kat.d
```