### PR TITLE
Extend the config grammar to allow comments in lists

### DIFF
--- a/katamari/resources/katamari/conf.abnf
+++ b/katamari/resources/katamari/conf.abnf
@@ -3,7 +3,7 @@ SECTION = HEADER ( <WS> / <COMMENT> / KEYVALUE ) *
 HEADER = <"["> #"[^\]]+" <"]"> <CLF>
 KEYVALUE = WORD < WS* "=" WS*> VALUE <CLF>
 VALUE = LIST / WORD
-LIST = <"["> ( <WS> / WORD ) * <"]">
+LIST = <"["> ( <WS> / WORD / <COMMENT> ) * <"]">
 WORD = (<"'"> #"[^']*" <"'">) / (<'"'> #'[^"]*' <'"'>) / #"[^\s=\[\],'\"]+" (* just a word *)
 COMMENT = #"^#.*?\n"
 WS = #"[\s,]*"


### PR DESCRIPTION
This allows me to interleave comments in the `kat.conf` namespaces list for instance to delineate sections or otherwise explain the intent.