### PR TITLE
Rewrite deps at prep time to achieve consistent behavior

### DIFF
--- a/src/katamari/src/katamari/server/extensions/roll_handlers.clj
+++ b/src/katamari/src/katamari/server/extensions/roll_handlers.clj
@@ -91,3 +91,30 @@ defaulting to the server's configured cache TTL."
            :msg "No TTL provided!"}
           (resp/response)
           (resp/status 400)))))
+
+(defhandler plan
+  "Plan the specified target(s), showing the plan, final config and rules.
+
+Usage:
+  ./kat plan target1 target2...
+"
+  [handler config stack request]
+  (case (first request)
+    "plan"
+    (if-let [targets (map symbol (rest request))]
+      (-> (zipmap
+           [:config :targets :plan]
+           (roll/plan config
+                      (or (:buildgraph config)
+                          (throw (ex-info "No buildgraph!" {})))
+                      targets))
+          (assoc :intent :json)
+          (resp/response)
+          (resp/status 200))
+
+      (-> {:intent :msg
+           :mgs "No target provided!"}
+          resp/response
+          (resp/status 400)))
+
+    (handler config stack request)))

--- a/src/roll-jvm/Rollfile
+++ b/src/roll-jvm/Rollfile
@@ -8,5 +8,6 @@
           org.clojure/clojure-tools nil
 
           me.arrdem/roll nil
+          me.arrdem/maxwell nil
 
           seancorfield/depstar nil}))

--- a/src/roll-jvm/src/roll/extensions/clj.clj
+++ b/src/roll-jvm/src/roll/extensions/clj.clj
@@ -3,7 +3,8 @@
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require [clojure.spec.alpha :as s]
             [roll.specs :as rs]
-            [roll.extensions :as ext]))
+            [roll.extensions :as ext]
+            [roll.extensions.jvm :as rejvm]))
 
 ;;;; Clojure library
 
@@ -14,6 +15,12 @@
 (ext/defmanifest clojure-library
   (s/keys* :opt-un [::rs/deps
                     ::rs/paths]))
+
+(defmethod ext/manifest-prep 'clojure-library [config buildgraph _manifest]
+  (rejvm/init-deps config buildgraph))
+
+(defmethod ext/rule-prep 'clojure-library [config buildgraph target rule]
+  (rejvm/canonicalize-deps config buildgraph target rule))
 
 (defmethod ext/rule-inputs 'clojure-library
   [config {:keys [targets] :as buildgraph} target rule]
@@ -26,7 +33,6 @@
 (defmethod ext/rule-build 'clojure-library
   [config buildgraph target rule products inputs]
   (merge
-   {:type ::product
-    :from target
+   {:from target
     :mvn/manifest :roll}
    (select-keys rule [:paths :deps])))

--- a/src/roll-jvm/src/roll/extensions/jar.clj
+++ b/src/roll-jvm/src/roll/extensions/jar.clj
@@ -39,6 +39,12 @@
                     ::entry-point
                     ::manifest]))
 
+(defmethod ext/manifest-prep 'jar [config buildgraph _manifest]
+  (rejvm/init-deps config buildgraph))
+
+(defmethod ext/rule-prep 'jar [config buildgraph target rule]
+  (rejvm/canonicalize-deps config buildgraph target rule))
+
 (defmethod ext/rule-inputs 'jar
   [config {:keys [targets] :as buildgraph} target rule]
 
@@ -71,6 +77,12 @@
            :opt-un [::jar-name
                     ::entry-point
                     ::manifest]))
+
+(defmethod ext/manifest-prep 'uberjar [config buildgraph _manifest]
+  (rejvm/init-deps config buildgraph))
+
+(defmethod ext/rule-prep 'uberjar [config buildgraph target rule]
+  (rejvm/canonicalize-deps config buildgraph target rule))
 
 (defmethod ext/rule-inputs 'uberjar
   [config {:keys [targets] :as buildgraph} target rule]

--- a/src/roll-jvm/src/roll/extensions/jvm.clj
+++ b/src/roll-jvm/src/roll/extensions/jvm.clj
@@ -53,12 +53,12 @@
 (defn merge-deps [& deps]
   (reader/merge-deps deps))
 
-(defn make-classpath [{:keys [::deps]
+(defn make-classpath [{init-deps ::deps
                        :as config}
                       products
                       deps]
   {:pre [(contains? deps :deps)]}
-  (let [deps (-> deps
+  (let [deps (-> (merge-deps init-deps deps)
                  ;; Inject the targets "profile"
                  (assoc-in [:aliases ::roll :override-deps]
                            (products->default-deps products)))

--- a/src/roll-jvm/src/roll/extensions/jvm.clj
+++ b/src/roll-jvm/src/roll/extensions/jvm.clj
@@ -2,26 +2,20 @@
   "A definition of `java-library`."
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require [clojure.java.shell :as sh]
-            [clojure.pprint :refer [pprint]]
             [clojure.spec.alpha :as s]
 
             ;; kat
-            [roll.reader :refer [compute-buildgraph refresh-buildgraph-for-changes]]
             [roll.specs :as rs]
             [roll.extensions :as ext]
 
             ;; deps
-            [clojure.tools.deps.alpha :as deps]
             [clojure.tools.deps.alpha.reader :as reader]
             [clojure.tools.deps.alpha.extensions :as deps.ext]
-            [clojure.tools.deps.alpha.util.io :as io :refer [printerrln]]
             [clojure.tools.deps.alpha.script.make-classpath :as mkcp]
             [clojure.tools.deps.alpha.script.parse :as deps-parser]
 
             ;; fs
-            [me.raynes.fs :as fs])
-  (:import [java.nio.file Files]
-           [java.nio.file.attribute FileAttribute]))
+            [me.raynes.fs :as fs]))
 
 ;;;; Interacting with deps
 
@@ -59,40 +53,77 @@
 (defn merge-deps [& deps]
   (reader/merge-deps deps))
 
-(defn make-classpath [{:keys [repo-root
-                              deps-defaults-file
-                              deps-defaults-data
-                              deps-resolve-file]
+(defn make-classpath [{:keys [::deps]
                        :as config}
                       products
                       deps]
   {:pre [(contains? deps :deps)]}
-  (let [deps (cond-> (-> deps
-                         ;; Inject the defaults "profile"
-                         (assoc-in [:aliases ::roll]
-                                   ;; FIXME (arrdem 2018-10-21):
-                                   ;;   Cache this
-                                   (deps-parser/parse-config
-                                    (slurp
-                                     (fs/file repo-root deps-resolve-file))))
-                         ;; Inject the targets "profile"
-                         (assoc-in [:aliases ::roll :override-deps]
-                                   (products->default-deps products)))
-
-               ;; defaults file
-               (not-empty deps-defaults-file)
-               (merge-deps (reader/read-deps
-                            [(fs/file repo-root deps-defaults-file)]))
-
-               ;; defaults data
-               (not-empty deps-defaults-data)
-               (merge-deps (deps-parser/parse-config deps-defaults-data)))
+  (let [deps (-> deps
+                 ;; Inject the targets "profile"
+                 (assoc-in [:aliases ::roll :override-deps]
+                           (products->default-deps products)))
         opts {:aliases [::roll]}]
 
     (mkcp/create-classpath
      deps
      ;; Bolt on our two magical internal profiles
      opts)))
+
+(defn init-deps
+  [{:keys [repo-root
+           deps-defaults-file
+           deps-defaults-data
+           deps-resolve-file
+           ::deps]
+    :as config}
+   buildgraph]
+  (if-not deps
+    (let [deps (cond-> {}
+                 (not-empty deps-resolve-file)
+                 (assoc-in [:aliases ::roll]
+                           ;; FIXME (arrdem 2018-10-21):
+                           ;;   Cache this
+                           (deps-parser/parse-config
+                            (slurp
+                             (fs/file repo-root deps-resolve-file))))
+
+                 ;; defaults file
+                 (not-empty deps-defaults-file)
+                 (merge-deps (reader/read-deps
+                              [(fs/file repo-root deps-defaults-file)]))
+
+                 ;; defaults data
+                 (not-empty deps-defaults-data)
+                 (merge-deps (deps-parser/parse-config deps-defaults-data)))]
+      [(assoc config ::deps deps) buildgraph])
+    [config buildgraph]))
+
+(defn- use-dep [default-deps override-deps [lib coord]]
+  (vector lib
+          (or (get override-deps lib)
+              (if-let [n (namespace lib)]
+                (get override-deps (symbol n)))
+              coord
+              (get default-deps lib)
+              (if-let [n (namespace lib)]
+                (get default-deps (symbol n))))))
+
+(defn canonicalize-deps [{:keys [::deps] :as config} buildgraph target rule]
+  [config
+   (-> buildgraph
+       (update-in [:targets target :deps]
+                  (fn [target-deps]
+                    (when target-deps
+                      (let [{:keys [default-deps
+                                    override-deps]}
+                            (-> deps :aliases ::roll)
+
+                            target-deps*
+                            (into {}
+                                  (map (partial use-dep default-deps override-deps))
+                                  target-deps)]
+                        (if (not= target-deps* target-deps)
+                          target-deps* target-deps))))))])
 
 ;;;; Java library
 
@@ -115,6 +146,12 @@
                     ::source-version
                     ::target-version]))
 
+(defmethod ext/manifest-prep 'java-library [config buildgraph _manifest]
+  (init-deps config buildgraph))
+
+(defmethod ext/rule-prep 'java-library [config buildgraph target rule]
+  (canonicalize-deps config buildgraph target rule))
+
 (defmethod ext/rule-inputs 'java-library
   [config {:keys [targets] :as buildgraph} target rule]
 
@@ -126,8 +163,8 @@
 
 (defmethod ext/rule-build 'java-library
   [config buildgraph target
-   {:keys [paths
-           deps
+   {:keys [deps
+           paths
            source-version
            target-version]
     :as rule}
@@ -142,7 +179,8 @@
         dest-dir (.getCanonicalPath fs/*cwd*)]
     (when source-files
       (let [cp (make-classpath config products
-                               {:deps (:deps target)})
+                               {:deps (:deps target)
+                                :paths paths})
             cmd (cond-> ["javac"]
                   (:classpath cp) (into ["-cp" (:classpath cp)])
                   source-version (into ["-source" source-version])
@@ -159,8 +197,7 @@
                                  :rule rule
                                  :command cmd))))))
 
-    {:type ::product
-     :from target
+    {:from target
      :mvn/manifest :roll
      :deps (:deps rule {})
      :paths [dest-dir]}))

--- a/src/roll/src/roll/core.clj
+++ b/src/roll/src/roll/core.clj
@@ -189,10 +189,10 @@
   supplied only that target and its dependencies.
 
   Return a mapping from built targets to their products."
-  [config cache {:keys [targets] :as buildgraph} & [targets?]]
+  [config cache buildgraph & [targets?]]
   (let [[config buildgraph plan] (plan config buildgraph targets?)]
     (reduce (fn [products target]
-              (let [rule    (get targets target)
+              (let [rule    (get-in buildgraph [:targets target])
                     inputs  (into {}
                                   (map (fn [[key targets]]
                                          [key (mapv #(get products %) targets)]))


### PR DESCRIPTION
This patch leverages the manifest prep time across all tools.deps (eg. JVM) backed targets to run some shared initializer code in the JVM extension that reads Katamari's current global default deps.edn data sources.

After that step in manifest prep, at rule prep time all the JVM manifests use the version pinning information currently somewhat magically delivered by the deps config to rewrite! their dependencies. This fixes #19 properly, by making the pinned and versioned deps part of the rule as it is content hashed for fingerprinting.

A (global) version bump will now cause target(s) to become stale.

Fixes #16, #19 

---

Also includes a `plan` task for inspecting the prepped buildgraph, config and resulting plan, as well as some work on Maxwell and the planning machinery required to get it working as documented and intended. It was pretty broken.