### PR TITLE
Enable Katamari to copy "products" out to the target tree

### DIFF
--- a/etc/bootstrap.sh
+++ b/etc/bootstrap.sh
@@ -3,8 +3,13 @@
 # A helper script for developing Katamari - lets kat re-uberjar itself, backs the current jar up,
 # tries to reboot into the new jar, and if that fails puts the old jar back.
 
-jar=$(./kat -j compile me.arrdem/katamari+uberjar | jq -r '.["me.arrdem/katamari+uberjar"]["paths"][0]')
-if [ -z "$jar" ]; then
+jar=target/katamari-standalone.jar
+
+[ ! -f "$jar" ] || rm "${jar}"
+
+./kat -j compile me.arrdem/katamari+uberjar
+
+if [ ! -f "$jar" ]; then
     exit 1
 else
     mv .kat.d/bootstrap.jar kat-backup.jar

--- a/src/roll-jvm/src/roll/extensions/jar.clj
+++ b/src/roll-jvm/src/roll/extensions/jar.clj
@@ -67,7 +67,7 @@
      {:type ::product
       :from target
       :mvn/manifest :roll
-      :paths [canonical-path]}
+      :products [canonical-path]}
      (select-keys rule [:deps]))))
 
 ;;;; Uberjars
@@ -113,5 +113,5 @@
      {:type ::product
       :from target
       :mvn/manifest :roll
-      :paths [canonical-path]}
+      :products [canonical-path]}
      (select-keys rule [:deps]))))


### PR DESCRIPTION
A sticking point for Katamari is the distinction between an intermediary build product with which the user really has no business such as a bunch of classfiles and a "final" product which a user will want to directly consume such as a jarfile.

This patch introduces the concept of a "product" of a target - being an array of paths naming files which could for instance be copied to Katamari's configured target directory once a build completes. This allows for some distinction between intermediary products which could participate in `:paths` and "terminal" products which a user may choose to copy around or otherwise use.